### PR TITLE
Fix build instructions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "maxpre2"]
 	path = maxpre2
-	url = git@bitbucket.org:coreo-group/maxpre2.git
+	url = https://bitbucket.org/coreo-group/maxpre2.git

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ If you use Loandra in your work please cite:
 - Berg, J., Demirović, E. and Stuckey, P.J., 2019. Core-boosted linear search for incomplete MaxSAT. In Integration of Constraint Programming, Artificial Intelligence, and Operations Research: 16th International Conference, CPAIOR 2019, Thessaloniki, Greece, June 4–7, 2019, Proceedings 16 (pp. 39-56). Springer International Publishing.
 
 ### Building
-First ensure the maxpre2 subfolder is updated. Newer versions of git do this automatically after cloning, with older versions you need 
-to run git submodule init and git submodule update in the maxpre2 subfolder. 
+Clone this repo with submodules. This can be done using `git clone --recurse-submodules git@github.com:jezberg/loandra.git`.
+Alternatively, make sure to go to the `maxpre2` folder, and run the `git submodule init` and `git submodule update`.
 
 Afterwards, run make in the base folder.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you use Loandra in your work please cite:
 - Berg, J., Demirović, E. and Stuckey, P.J., 2019. Core-boosted linear search for incomplete MaxSAT. In Integration of Constraint Programming, Artificial Intelligence, and Operations Research: 16th International Conference, CPAIOR 2019, Thessaloniki, Greece, June 4–7, 2019, Proceedings 16 (pp. 39-56). Springer International Publishing.
 
 ### Building
-Clone this repo with submodules. This can be done using `git clone --recurse-submodules git@github.com:jezberg/loandra.git`.
+Clone this repo with submodules. This can be done using `git clone --recurse-submodules https://github.com/jezberg/loandra.git`.
 Alternatively, make sure to go to the `maxpre2` folder, and run the `git submodule init` and `git submodule update`.
 
 Afterwards, run make in the base folder.


### PR DESCRIPTION
Git does not automatically clone submodules. The commandline flag is still there in the documentation https://git-scm.com/docs/git-clone

It's just good Git Clients that will automatically deal with submodules.

I also had to change the URL in the `.gitmodules` file to use HTTPS, since the SSH option only works if BitBucket knows and accepts one's SSH key. That obviously works for people who have access to the BitBucket repo, but breaks for everyone else.